### PR TITLE
Top scrollbar fix: more precise dimensions

### DIFF
--- a/jquery.doubleScroll.js
+++ b/jquery.doubleScroll.js
@@ -57,8 +57,8 @@
             self.element.css(self.options.contentCss);
 
             // set the width of the wrappers
-            $(self.options.topScrollBarInnerSelector, topScrollBar).width(contentElement.outerWidth());
-            topScrollBar.width(self.element.width());
+            $(self.options.topScrollBarInnerSelector, topScrollBar).width(contentElement[0].scrollWidth);
+            topScrollBar.width(self.element[0].clientWidth);
         },
         refresh: function(){
             // this should be called if the content of the inner element changed.
@@ -76,8 +76,8 @@
             }
 
             // set the width of the wrappers
-            $(self.options.topScrollBarInnerSelector, topScrollBar).width(contentElement.outerWidth());
-            topScrollBar.width(self.element.width());
+            $(self.options.topScrollBarInnerSelector, topScrollBar).width(contentElement[0].scrollWidth);
+            topScrollBar.width(self.element[0].clientWidth);
         }
     });
 })(jQuery);


### PR DESCRIPTION
First, I want to thank you for your plugin! It was exactly what I wanted.
But when i started to use it I've noticed a small difference between top and bottom scrollbars. I started to dig where it comes from and I find out that $.outherWidth() is not so precise when it comes to scrollbars... So I used JS native properties scrollWidth and clientWidth. With them your plugin just works perfectly. Pull my commit please, perhaps some day it will help someone, like your plugin helped me once.
